### PR TITLE
Persist current article read as part of bulk_persist_articles

### DIFF
--- a/article/helpers.py
+++ b/article/helpers.py
@@ -59,15 +59,12 @@ def total_time_to_read_multiple_articles(articles):
 
 
 class BaseArticleReadManager(abc.ABC):
-    def __init__(self, request):
+    def __init__(self, request, current_article=None):
         self.request = request
+        self.current_article = current_article
 
     @abc.abstractmethod
-    def persist_article(self, article_uuid):
-        pass
-
-    @abc.abstractmethod
-    def retrieve_article_uuids(self):
+    def retrieve_historic_article_uuids(self):
         return
 
     def get_group_read_progress(self):
@@ -110,56 +107,50 @@ class BaseArticleReadManager(abc.ABC):
 
     @cached_property
     def read_article_uuids(self):
-        return self.retrieve_article_uuids()
+        uuids = self.retrieve_historic_article_uuids()
+        if self.current_article:
+            uuids.add(self.current_article.uuid)
+        return uuids
 
 
 class ArticleReadManager:
-    def __new__(cls, request):
-        session_manager = SessionArticlesReadManager(request)
-        database_manager = DatabaseArticlesReadManager(request)
-
+    def __new__(cls, request, current_article=None):
+        session_manager = SessionArticlesReadManager(request, current_article)
+        database_manager = DatabaseArticlesReadManager(
+            request, current_article
+        )
         if request.sso_user is None:
+            if current_article:
+                session_manager.persist_article(current_article.uuid)
             return session_manager
-        uuids = session_manager.retrieve_article_uuids()
-        if uuids:
-            response = database_manager.bulk_persist_article(uuids)
-            if response.ok:
-                session_manager.clear()
+        response = database_manager.bulk_persist_article(
+            article_uuids=session_manager.read_article_uuids
+        )
+        if response.ok:
+            session_manager.clear()
         return database_manager
 
 
 class SessionArticlesReadManager(BaseArticleReadManager):
     SESSION_KEY = 'ARTICLES_READ'
 
-    def __init__(self, request):
-        super().__init__(request)
-        self.session = request.session
-
     def persist_article(self, article_uuid):
-        articles = self.session.get(self.SESSION_KEY, [])
+        articles = self.request.session.get(self.SESSION_KEY, [])
         articles.append(article_uuid)
-        self.session[self.SESSION_KEY] = articles
-        self.session.modified = True
+        self.request.session[self.SESSION_KEY] = articles
+        self.request.session.modified = True
 
-    def retrieve_article_uuids(self):
+    def retrieve_historic_article_uuids(self):
         uuids = self.request.session.get(self.SESSION_KEY, [])
-        return frozenset(uuids)
+        return set(uuids)
 
     def clear(self):
-        self.session[self.SESSION_KEY] = []
+        self.request.session[self.SESSION_KEY] = []
 
 
 class DatabaseArticlesReadManager(BaseArticleReadManager):
 
-    article_uuids = frozenset()
-
-    def persist_article(self, article_uuid):
-        response = api_client.exportreadiness.create_article_read(
-            article_uuid=article_uuid,
-            sso_session_id=self.request.sso_user.session_id,
-        )
-        log_response(response)
-        return response
+    article_uuids = set()
 
     def bulk_persist_article(self, article_uuids):
         response = api_client.exportreadiness.bulk_create_article_read(
@@ -168,12 +159,12 @@ class DatabaseArticlesReadManager(BaseArticleReadManager):
         )
         log_response(response)
 
-        self.article_uuids = frozenset(
+        self.article_uuids = set(
             [article['article_uuid'] for article in response.json()]
         )
         return response
 
-    def retrieve_article_uuids(self):
+    def retrieve_historic_article_uuids(self):
         # for performance gains (ED-2822) the articles are returned by API when
         # bulk_persist_article was called by ArticleReadManager
         return self.article_uuids

--- a/article/views.py
+++ b/article/views.py
@@ -1,20 +1,18 @@
 from django.views.generic import TemplateView
 from django.utils.functional import cached_property
 
-from article import articles, structure
+from article import articles, helpers, structure
 from core.helpers import build_social_links
-from core.views import ArticleReadMixin
+from core.views import ArticleReadManagerMixin
 
 
-class BaseArticleDetailView(ArticleReadMixin, TemplateView):
+class BaseArticleDetailView(ArticleReadManagerMixin, TemplateView):
     template_name = 'article/detail-base.html'
 
-    def get(self, request, *args, **kwargs):
-        self.record_article_visit()
-        return super().get(request, *args, **kwargs)
-
-    def record_article_visit(self):
-        self.request.article_read_manager.persist_article(self.article.uuid)
+    def create_article_manager(self, request):
+        return helpers.ArticleReadManager(
+            request=request, current_article=self.article
+        )
 
     def get_context_data(self, *args, **kwargs):
         social_links = build_social_links(
@@ -70,7 +68,7 @@ class BaseArticleDetailView(ArticleReadMixin, TemplateView):
         return self.article_group.next_guidance_group
 
 
-class BaseArticleListView(ArticleReadMixin, TemplateView):
+class BaseArticleListView(ArticleReadManagerMixin, TemplateView):
 
     def get_context_data(self, *args, **kwargs):
         return super().get_context_data(

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -1,7 +1,5 @@
 from django.conf import settings
 
-from article.helpers import ArticleReadManager
-
 
 class NoCacheMiddlware:
     """Tell the browser to not cache the pages.
@@ -23,9 +21,3 @@ class NoCacheMiddlware:
         if getattr(request, 'sso_user', None):
             response['Cache-Control'] = 'no-store, no-cache'
         return response
-
-
-class ArticleReadManagerMiddlware:
-
-    def process_request(self, request):
-        request.article_read_manager = ArticleReadManager(request=request)

--- a/core/views.py
+++ b/core/views.py
@@ -4,15 +4,26 @@ from django.utils.cache import set_response_etag
 from django.views.generic import TemplateView
 from django.views.generic.base import RedirectView
 
-from triage.helpers import TriageAnswersManager
+from article.helpers import ArticleReadManager
 from casestudy import casestudies
+from triage.helpers import TriageAnswersManager
 from ui.views import TranslationsMixin
 
 
-class ArticleReadMixin:
+class ArticleReadManagerMixin:
+
+    article_read_manager = None
+
+    def create_article_manager(self, request):
+        return ArticleReadManager(request=request)
+
+    def dispatch(self, request, *args, **kwargs):
+        self.article_read_manager = self.create_article_manager(request)
+        return super().dispatch(request, *args, **kwargs)
+
     def get_article_group_progress_details(self):
         name = self.article_group.name
-        manager = self.request.article_read_manager
+        manager = self.article_read_manager
         read_article_uuids = manager.read_articles_keys_in_group(name)
         return {
             'read_article_uuids': read_article_uuids,

--- a/triage/tests/test_views.py
+++ b/triage/tests/test_views.py
@@ -15,7 +15,9 @@ from article import structure
 
 @pytest.fixture(autouse=True)
 def mock_retrive_articles_read():
-    mock = patch('api_client.api_client.exportreadiness.retrieve_article_read')
+    mock = patch(
+        'api_client.api_client.exportreadiness.bulk_create_article_read'
+    )
     mock.return_value = create_response(200, json_body=[])
     yield mock.start()
     mock.stop()

--- a/triage/views.py
+++ b/triage/views.py
@@ -10,7 +10,7 @@ from django.views.generic import View
 
 from article import structure
 from casestudy import casestudies
-from core.views import ArticleReadMixin
+from core.views import ArticleReadManagerMixin
 from triage import forms, helpers
 
 
@@ -160,7 +160,7 @@ class TriageWizardFormView(NamedUrlSessionWizardView):
         return redirect(self.success_url)
 
 
-class CustomPageView(ArticleReadMixin, TemplateView):
+class CustomPageView(ArticleReadManagerMixin, TemplateView):
     http_method_names = ['get']
     template_name = 'triage/custom-page.html'
 
@@ -190,7 +190,7 @@ class CustomPageView(ArticleReadMixin, TemplateView):
             casestudies.YORK,
         ]
         context['article_group_read_progress'] = (
-            self.request.article_read_manager.get_group_read_progress()
+            self.article_read_manager.get_group_read_progress()
         )
         sector_code = self.triage_answers['sector']
         # harmonised system codes begin with HS. Service codes begin with EB

--- a/ui/settings.py
+++ b/ui/settings.py
@@ -67,7 +67,6 @@ MIDDLEWARE_CLASSES = [
     'ui.middleware.LocaleQuerystringMiddleware',
     'ui.middleware.PersistLocaleMiddleware',
     'ui.middleware.ForceDefaultLocale',
-    'core.middleware.ArticleReadManagerMiddlware',
 ]
 
 ROOT_URLCONF = 'ui.urls'


### PR DESCRIPTION
[part of this task](https://uktrade.atlassian.net/browse/ED-2822)

Currently viewing articles results in two API calls. With this change, it only does one.

on master local dev env article pages take 100ns, On this branch they take 75ms. We may see a 25% speed improvement in other environments.
