### PR TITLE
Fix 400 response template

### DIFF
--- a/core/templates/400.html
+++ b/core/templates/400.html
@@ -1,4 +1,4 @@
-{% extends 'enrolment-base.html' %}
+{% extends 'core/base.html' %}
 {% load external_url from constants_tags %}
 {% block sub_header %}{# prevent the subheader from showing on form pages #}{% endblock %}
 {% block content %}

--- a/core/tests/test_templates.py
+++ b/core/tests/test_templates.py
@@ -1,0 +1,12 @@
+from django.template.loader import render_to_string
+
+import pytest
+
+
+@pytest.mark.parametrize('template_name', (
+    '400.html',
+    '403.html',
+    '404.html',
+))
+def test_error_templates(template_name):
+    assert render_to_string(template_name, {})


### PR DESCRIPTION
[this task](https://uktrade.atlassian.net/browse/ED-2877)

The content was copied from FAB to ExRed. FAB's base template is called enrolment-base.html, while ExRed is base.html

And the templates were not rendered during testing.
