### PR TITLE
Refactor article read manager

### DIFF
--- a/article/helpers.py
+++ b/article/helpers.py
@@ -7,128 +7,92 @@ from django.template.loader import render_to_string
 from django.utils.functional import cached_property
 
 from api_client import api_client
-from . import structure
+from article import structure
 
 
 WORDS_PER_SECOND = 1.5  # Average word per second on screen
 
 
 def markdown_to_html(markdown_file_path, context={}):
-    html = render_to_string(markdown_file_path, context)
-    return markdown2.markdown(html, extras=["target-blank-links"])
+    content = render_to_string(markdown_file_path, context)
+    return markdown2.markdown(content, extras=["target-blank-links"])
 
 
-def filter_lines(lines_list):
-    """BeautifulSoup returns \n as lines as well, we filter them out.
-
-    It's a function because more filtering can be added later.
-    """
-    return filter(lambda x: x != '\n', lines_list)
-
-
-def lines_list_from_html(html):
-    """Parses the HTML to return text lines."""
-    soup = BeautifulSoup(html, 'html.parser')
-    return soup.findAll(text=True)
-
-
-def count_average_word_number_in_lines_list(lines_list, word_length=5):
-    """Assume average word length, counts how many words in all the lines."""
-    total_words = 0
-    for line in lines_list:
-        total_words += len(line)/word_length
-    return total_words
+def get_word_count(html):
+    soup = BeautifulSoup(html.replace('\n', ''), 'html.parser')
+    words = ''.join(soup.findAll(text=True)).strip()
+    return len(words.split(' '))
 
 
 def time_to_read_in_seconds(article):
-    """Return time to read in minutes give an Article object."""
     html = markdown_to_html(article.markdown_file_path)
-    lines_list = lines_list_from_html(html)
-    filtered_lines_list = filter_lines(lines_list)
-    total_words_count = count_average_word_number_in_lines_list(
-        filtered_lines_list
-    )
-    return round(total_words_count / WORDS_PER_SECOND)
+    return round(get_word_count(html) / WORDS_PER_SECOND)
 
 
-def total_time_to_read_multiple_articles(articles):
-    return sum((article.time_to_read for article in articles))
-
-
-class BaseArticleReadManager(abc.ABC):
-    def __init__(self, request, current_article=None):
+class BaseArticlesViewedManager(abc.ABC):
+    def __init__(self, request):
         self.request = request
-        self.current_article = current_article
 
-    @abc.abstractmethod
-    def retrieve_historic_article_uuids(self):
-        return
-
-    def get_group_read_progress(self):
+    def get_view_progress_for_groups(self):
         return {
             group.name: {
-                'read': len(self.read_article_uuids & group.articles_set),
-                'total': len(group.articles_set),
+                'read': len(self.viewed_article_uuids & group.article_uuids),
+                'total': len(group.article_uuids),
             }
             for group in structure.ALL_GROUPS
         }
 
-    def read_articles_keys_in_group(self, group_name):
-        article_uuids = structure.get_article_group(group_name).articles_set
-        # read_articles_in_category is a new set (intersection)
-        # with elements common to read_articles and articles_in_category
-        read_articles_in_group = self.read_article_uuids & article_uuids
-        return read_articles_in_group
+    def articles_viewed_for_group(self, group_name):
+        group = structure.get_article_group(group_name)
+        # `&` performs an intersection of items in both sets
+        return self.viewed_article_uuids & group.article_uuids
 
-    def article_read_count(self, group_name):
-        return len(self.read_articles_keys_in_group(group_name))
-
-    def remaining_reading_time_in_group(self, group_name):
-        """ Return the remaining reading time in minutes
-            for unread articles in the group
-        """
-
-        read_articles_uuids_in_group = self.read_articles_keys_in_group(
-            group_name
-        )
-        read_articles = structure.get_articles_from_uuids(
-            read_articles_uuids_in_group
-        )
-        read_articles_total_time = total_time_to_read_multiple_articles(
-            read_articles
-        )
-        group_total_reading_time = structure.get_article_group(
-            group_name
-        ).total_reading_time
-        return round(group_total_reading_time - read_articles_total_time, 2)
+    def remaining_read_time_for_group(self, group_name):
+        group = structure.get_article_group(group_name)
+        return group.remaining_time_to_read(self.viewed_article_uuids)
 
     @cached_property
-    def read_article_uuids(self):
-        uuids = self.retrieve_historic_article_uuids()
-        if self.current_article:
-            uuids.add(self.current_article.uuid)
-        return uuids
+    def viewed_article_uuids(self):
+        return self.retrieve_viewed_article_uuids()
+
+    @abc.abstractmethod
+    def retrieve_viewed_article_uuids(self):
+        return
 
 
-class ArticleReadManager:
+class ArticlesViewedManagerFactory:
     def __new__(cls, request, current_article=None):
-        session_manager = SessionArticlesReadManager(request, current_article)
-        database_manager = DatabaseArticlesReadManager(
-            request, current_article
-        )
         if request.sso_user is None:
-            if current_article:
-                session_manager.persist_article(current_article.uuid)
-            return session_manager
-        response = database_manager.bulk_persist_article(
-            article_uuids=session_manager.read_article_uuids
-        )
+            factory_function = cls.get_session_articles_viewed_manager
+        else:
+            factory_function = cls.get_database_articles_viewed_manager
+        return factory_function(request, current_article)
+
+    @staticmethod
+    def get_session_articles_viewed_manager(request, current_article):
+        session_manager = SessionArticlesViewedManager(request)
+        if current_article:
+            session_manager.persist_article(current_article.uuid)
+        return session_manager
+
+    @staticmethod
+    def get_database_articles_viewed_manager(request, current_article):
+        session_manager = SessionArticlesViewedManager(request)
+        database_manager = DatabaseArticlesViewedManager(request)
+
+        # write article views stored in the session to the database
+        viewed_article_uuids = set()
+        if current_article:
+            viewed_article_uuids.add(current_article.uuid)
+        if session_manager.viewed_article_uuids:
+            viewed_article_uuids.update(session_manager.viewed_article_uuids)
+        response = database_manager.persist_articles(viewed_article_uuids)
         if response.ok:
             session_manager.clear()
         return database_manager
 
 
-class SessionArticlesReadManager(BaseArticleReadManager):
+class SessionArticlesViewedManager(BaseArticlesViewedManager):
     SESSION_KEY = 'ARTICLES_READ'
 
     def persist_article(self, article_uuid):
@@ -137,7 +101,7 @@ class SessionArticlesReadManager(BaseArticleReadManager):
         self.request.session[self.SESSION_KEY] = articles
         self.request.session.modified = True
 
-    def retrieve_historic_article_uuids(self):
+    def retrieve_viewed_article_uuids(self):
         uuids = self.request.session.get(self.SESSION_KEY, [])
         return set(uuids)
 
@@ -145,11 +109,11 @@ class SessionArticlesReadManager(BaseArticleReadManager):
         self.request.session[self.SESSION_KEY] = []
 
 
-class DatabaseArticlesReadManager(BaseArticleReadManager):
+class DatabaseArticlesViewedManager(BaseArticlesViewedManager):
 
     article_uuids = set()
 
-    def bulk_persist_article(self, article_uuids):
+    def persist_articles(self, article_uuids):
         response = api_client.exportreadiness.bulk_create_article_read(
             article_uuids=article_uuids,
             sso_session_id=self.request.sso_user.session_id,
@@ -160,7 +124,7 @@ class DatabaseArticlesReadManager(BaseArticleReadManager):
         )
         return response
 
-    def retrieve_historic_article_uuids(self):
+    def retrieve_viewed_article_uuids(self):
         # for performance gains (ED-2822) the articles are returned by API when
-        # bulk_persist_article was called by ArticleReadManager
+        # bulk_persist_article was called by ArticleViewedManager
         return self.article_uuids

--- a/article/structure.py
+++ b/article/structure.py
@@ -12,15 +12,21 @@ class ArticleGroup:
         self.title = title
         self.url = url
         self.next_guidance_group = next_guidance_group
-        self.articles_set = frozenset(
+        self.article_uuids = frozenset(
             [article.uuid for article in self.articles]
         )
 
     @cached_property
-    def total_reading_time(self):
+    def read_time(self):
         return round(
             sum((article.time_to_read for article in self.articles))
         )
+
+    def remaining_time_to_read(self, viewed_article_uuids):
+        uuids = viewed_article_uuids & self.article_uuids
+        articles = get_articles_from_uuids(uuids)
+        viewed_time = sum((article.time_to_read for article in articles))
+        return round(self.read_time - viewed_time, 2)
 
 
 PERSONA_NEW_ARTICLES = ArticleGroup(

--- a/article/templates/article/list-base.html
+++ b/article/templates/article/list-base.html
@@ -34,7 +34,7 @@
                 {% for article in article_group.articles %}
                     <li>
                         <span class="section">{{ article.parent.title }}<span class="verbose">:</span>&nbsp;</span>
-                        <a href="{{ article.url }}?source={{article_group.name}}" class="article{% if article.uuid in article_group_progress.read_article_uuids %} article-read{% endif %}">{{ article.title }}</a>
+                        <a href="{{ article.url }}?source={{article_group.name}}" class="article{% if article.uuid in article_group_progress.viewed_article_uuids %} article-read{% endif %}">{{ article.title }}</a>
                     </li>
                 {% endfor %}
                 <div class="buttons">

--- a/article/tests/test_articles.py
+++ b/article/tests/test_articles.py
@@ -3,4 +3,4 @@ from article import articles
 
 def test_article_time_to_read():
     article = articles.CONSIDER_HOW_PAID
-    assert article.time_to_read == 36
+    assert article.time_to_read == 24

--- a/article/tests/test_structure.py
+++ b/article/tests/test_structure.py
@@ -28,9 +28,9 @@ def test_get_articles_from_uuids():
     assert list(articles_returned) == articles_list
 
 
-def test_article_group_total_reading_time():
+def test_article_group_read_time():
     group = structure.PERSONA_NEW_ARTICLES
-    assert group.total_reading_time == 2050
+    assert group.read_time == 1625
 
 
 @pytest.mark.parametrize(

--- a/article/views.py
+++ b/article/views.py
@@ -3,14 +3,14 @@ from django.utils.functional import cached_property
 
 from article import articles, helpers, structure
 from core.helpers import build_social_links
-from core.views import ArticleReadManagerMixin
+from core.views import ArticlesViewedManagerMixin
 
 
-class BaseArticleDetailView(ArticleReadManagerMixin, TemplateView):
+class BaseArticleDetailView(ArticlesViewedManagerMixin, TemplateView):
     template_name = 'article/detail-base.html'
 
     def create_article_manager(self, request):
-        return helpers.ArticleReadManager(
+        return helpers.ArticlesViewedManagerFactory(
             request=request, current_article=self.article
         )
 
@@ -68,7 +68,7 @@ class BaseArticleDetailView(ArticleReadManagerMixin, TemplateView):
         return self.article_group.next_guidance_group
 
 
-class BaseArticleListView(ArticleReadManagerMixin, TemplateView):
+class BaseArticleListView(ArticlesViewedManagerMixin, TemplateView):
 
     def get_context_data(self, *args, **kwargs):
         return super().get_context_data(

--- a/triage/templates/triage/custom-page.html
+++ b/triage/templates/triage/custom-page.html
@@ -94,7 +94,7 @@
                 {% for article in section_configuration.persona_article_group.articles %}
                     <li>
                         <span class="section">{{ article.parent.title }}<span class="verbose">:</span>&nbsp;</span>
-                        <a href="{{ article.url }}?source={{ article_group.name }}" class="article{% if article.uuid in article_group_progress.read_article_uuids %} article-read{% endif %}">{{ article.title }}</a>
+                        <a href="{{ article.url }}?source={{ article_group.name }}" class="article{% if article.uuid in article_group_progress.viewed_article_uuids %} article-read{% endif %}">{{ article.title }}</a>
                     </li>
                 {% endfor %}
                 <div class="buttons">

--- a/triage/views.py
+++ b/triage/views.py
@@ -10,7 +10,7 @@ from django.views.generic import View
 
 from article import structure
 from casestudy import casestudies
-from core.views import ArticleReadManagerMixin
+from core.views import ArticlesViewedManagerMixin
 from triage import forms, helpers
 
 
@@ -160,7 +160,7 @@ class TriageWizardFormView(NamedUrlSessionWizardView):
         return redirect(self.success_url)
 
 
-class CustomPageView(ArticleReadManagerMixin, TemplateView):
+class CustomPageView(ArticlesViewedManagerMixin, TemplateView):
     http_method_names = ['get']
     template_name = 'triage/custom-page.html'
 
@@ -190,7 +190,7 @@ class CustomPageView(ArticleReadManagerMixin, TemplateView):
             casestudies.YORK,
         ]
         context['article_group_read_progress'] = (
-            self.article_read_manager.get_group_read_progress()
+            self.article_read_manager.get_view_progress_for_groups()
         )
         sector_code = self.triage_answers['sector']
         # harmonised system codes begin with HS. Service codes begin with EB


### PR DESCRIPTION
[this task](https://uktrade.atlassian.net/browse/ED-2947)

- "read" can refer to _the action of reading_ or _the state of having been read_ - so it's confusing ot call something a `ReadManager` and methods that use the word `read`. To solve this instead use the words"view" and "viewed"
- the article read manager was too stateful. now it is less stateful.
- the "time to read article" code assumes each row has 5 words. No need to make that assumption.
