### PR TITLE
Remove obsolete success page

### DIFF
--- a/conf/urls.py
+++ b/conf/urls.py
@@ -652,11 +652,6 @@ contact_urls = [
         name='contact-us-feedback-success'
     ),
     url(
-        r'^contact/find-uk-companies/success/$',
-        contact.views.BuyingFromUKCompaniesSuccessView.as_view(),
-        name='contact-us-find-uk-companies-success'
-    ),
-    url(
         r'^contact/domestic/$',
         contact.views.DomesticFormView.as_view(),
         name='contact-us-domestic'

--- a/contact/tests/test_views.py
+++ b/contact/tests/test_views.py
@@ -291,10 +291,6 @@ def test_notify_form_submit_success(
         cms.EXPORT_READINESS_CONTACT_US_FORM_SUCCESS_FEEDBACK_SLUG,
     ),
     (
-        reverse('contact-us-find-uk-companies-success'),
-        cms.EXPORT_READINESS_CONTACT_US_FORM_SUCCESS_FIND_COMPANIES_SLUG,
-    ),
-    (
         reverse('contact-us-domestic-success'),
         cms.EXPORT_READINESS_CONTACT_US_FORM_SUCCESS_SLUG,
     ),
@@ -532,7 +528,6 @@ success_urls = (
     reverse('contact-us-dso-success'),
     reverse('contact-us-export-advice-success'),
     reverse('contact-us-feedback-success'),
-    reverse('contact-us-find-uk-companies-success'),
     reverse('contact-us-domestic-success'),
     reverse('contact-us-international-success'),
 )

--- a/contact/views.py
+++ b/contact/views.py
@@ -387,10 +387,6 @@ class FeedbackSuccessView(BaseSuccessView):
     slug = cms.EXPORT_READINESS_CONTACT_US_FORM_SUCCESS_FEEDBACK_SLUG
 
 
-class BuyingFromUKCompaniesSuccessView(BaseSuccessView):
-    slug = cms.EXPORT_READINESS_CONTACT_US_FORM_SUCCESS_FIND_COMPANIES_SLUG
-
-
 class GuidanceView(mixins.GetCMSPageMixin, TemplateView):
     template_name = 'contact/guidance.html'
 


### PR DESCRIPTION
nothing links to this page. it was created before I realised that the external FAS form handles this case.