### PR TITLE
lock python build pack version

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,4 +2,4 @@
 applications:
 - name: directory-ui-export-readiness
   memory: 512M
-  buildpack: python_buildpack
+  buildpack: https://github.com/cloudfoundry/python-buildpack.git#v1.6.25


### PR DESCRIPTION
This is required so when GDS update there buildpacks this build is not effected.